### PR TITLE
Fix hard coding of set department for new course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -23,9 +23,8 @@ class CoursesController < ApplicationController
 
   def create
     @course = Course.new(course_params)
-
     if @course.save
-      @course.set_department
+      @course.set_department(params[:course][:department_id])
       redirect_to courses_path
     else
       render 'new'

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,18 +12,9 @@ class Course < ActiveRecord::Base
     total_seats && total_seats > 0 ? total_seats : 0
   end
 
-  def set_department
-    case
-    when self.number.include?("ART") then self.department_id = 1
-    when self.number.include?("MTH") then self.department_id = 2
-    when self.number.include?("SCI") then self.department_id = 3
-    when self.number.include?("IAS") then self.department_id = 4
-    when self.number.include?("LAS") then self.department_id = 5
-    when self.number.include?("ENG") then self.department_id = 6
-    when self.number.include?("PED") then self.department_id = 7
-    else
-      self.department_id = 8
-    end
+  def set_department(params)
+    self.department_id = params
+    self.save
   end
 
 end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -7,6 +7,19 @@
   </ul>
 <% end %>
 
+
+
+
+<div class="form-group">
+  <%= form.collection_select(:department_id, Department.all, :id, :name) do |b| %>
+    <%= b.label(class: "radio-button") { b.radio_button(class: "radio_button") }  %>
+  <% end %>
+</div>
+
+
+
+
+
 <div class="form-group">
   <%= form.label :name, class: "col-md-2 control-label text-right" %>
   <div class="col-md-10">


### PR DESCRIPTION
When creating a new course, the department was previously set by finding the name of the department in the course code. Realized that wouldn't work: the system I was using was only for testing, it will be in a completely different format. Now it will work for any format of course code, as long as the department has been created and it is listed in the dropdown. 
